### PR TITLE
Add a basic installer script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+PRGM = swaylock-fancy
+PREFIX ?= /usr
+SHRDIR ?= $(PREFIX)/share
+BINDIR ?= $(PREFIX)/bin
+
+install:
+		@install -Dm755 lock.py        $(DESTDIR)$(BINDIR)/$(PRGM)
+		@install -Dm755 lock.png       -t $(DESTDIR)$(SHRDIR)/$(PGRM)/icons
+		@install -Dm644 LICENSE        -t $(DESTDIR)$(SHRDIR)/licenses/$(PRGM)
+

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ which also somewhat inspired this script.
   * [sway (swaylock)](https://github.com/swaywm/sway)
   * [Pillow](https://pillow.readthedocs.io/)
 
+## Installation
+
+Git clone the repository, change to it and run `make install` as root:
+
+```bash
+git clone --depth 1 https://github.com/janoliver/swaylock-fancy.git && cd swaylock-fancy
+make install
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
Just added a very basic installer script and updated the readme file with install instructions.

#### Testing

Fetch the PR and run as root:

```bash
make install
```

P.S.: Maybe the python script should be modified to look in the install folder for the lock.png